### PR TITLE
Fix for Python 3.12

### DIFF
--- a/src/pytest_venv/__init__.py
+++ b/src/pytest_venv/__init__.py
@@ -26,6 +26,7 @@ class VirtualEnvironment(object):
     def create(self, system_packages=False, python=None):
         cmd = [sys.executable, '-m', 'virtualenv']
         cmd += ['-p', python or sys.executable]
+        cmd += ['--setuptools=bundle']
         if system_packages:
             cmd += ['--system-site-packages']
         cmd += [self.path]


### PR DESCRIPTION
virtualenv 20.23.0 will no longer install setuptools and wheel by default when run with Python 3.12:

https://github.com/pypa/virtualenv/pull/2558

This causes the `pkg_resources` call in pytest-venv to fail, as that is installed together with setuptools.  Use the virtualenv command line argument to restore the previous behaviour.

The alternative would be to replace the `pkg_resources` call with a `pip` API call, as pip is still installed by default with 3.12.
